### PR TITLE
Release 1.0.1 -- bump terraform version to 1.1.0 

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,7 @@
 
 terraform {
-  required_version = ">= 0.12"
+  // version 1.1.0 is required for the "moved" block
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION

### Fixed
- Change Terraform minimum required version to 1.1.0 because of the "moved" block.
